### PR TITLE
use pytest-xdist to parallelize test_display (on a single runner)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,10 @@ jobs:
           # dependencies, to make sure the cache doesn't go stale
           pip install --upgrade --upgrade-strategy eager -e .
           pip install --upgrade --upgrade-strategy eager pytest-cov
+          pip install --upgrade --upgrade-strategy eager pytest-xdist
       - name: Run tests with pytest
-        run: 'pytest --cov=plenoptic tests/test_${{ matrix.test_script }}.py'
+        # we have two cores on the linux github action runners:
+        # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
+        run: 'pytest -n 2 --cov=plenoptic tests/test_${{ matrix.test_script }}.py'
       - name: Upload to codecov
         run: 'bash <(curl -s https://codecov.io/bash)'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,18 @@ jobs:
           # dependencies, to make sure the cache doesn't go stale
           pip install --upgrade --upgrade-strategy eager -e .
           pip install --upgrade --upgrade-strategy eager pytest-cov
-          pip install --upgrade --upgrade-strategy eager pytest-xdist
+
       - name: Run tests with pytest
+        if: ${{ matrix.test_script == 'display' }}
         # we have two cores on the linux github action runners:
         # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
-        run: 'pytest -n 2 --cov=plenoptic tests/test_${{ matrix.test_script }}.py'
+        run: |
+          pip install --upgrade --upgrade-strategy eager pytest-xdist
+          pytest -n 2 --cov=plenoptic tests/test_${{ matrix.test_script }}.py
+      - name: Run tests with pytest
+        if: ${{ matrix.test_script != 'display' }}
+        # only test_display should parallelize across the cores, the others get
+        # slowed down by it
+        run: 'pytest --cov=plenoptic tests/test_${{ matrix.test_script }}.py'
       - name: Upload to codecov
         run: 'bash <(curl -s https://codecov.io/bash)'


### PR DESCRIPTION
This PR adds the use of the `pytest-xdist` plugin to parallelize the `test_display.py` script (on a single runner; our tests are also parallelized across runners). The others are run as normal. This reduces the time required for `test_display` from ~30 minutes to ~20, while the others are unchanged.