### PR TITLE
hotfix for weird caching issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,17 @@ jobs:
       - name: Cache environment
         uses: actions/cache@v2
         with:
-          path: ${{ env.pythonLocation }}
+          # Cache the Python package environment, excluding pip and setuptools
+          # installed by setup-python, following
+          # https://github.com/pypa/pip/issues/9880
+          path: |
+            ~/.cache/pip
+            ${{ env.pythonLocation }}/bin/*
+            ${{ env.pythonLocation }}/include
+            ${{ env.pythonLocation }}/lib/python*/site-packages/*
+            !${{ env.pythonLocation }}/bin/pip*
+            !${{ env.pythonLocation }}/lib/python*/site-packages/pipe*
+            !${{ env.pythonLocation }}/lib/python*/site-packages/setuptools*
           key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}
       - name: Install dependencies
         run: |

--- a/.github/workflows/treebeard.yml
+++ b/.github/workflows/treebeard.yml
@@ -28,7 +28,17 @@ jobs:
       - name: Cache environment
         uses: actions/cache@v2
         with:
-          path: ${{ env.pythonLocation }}
+          # Cache the Python package environment, excluding pip and setuptools
+          # installed by setup-python, following
+          # https://github.com/pypa/pip/issues/9880
+          path: |
+            ~/.cache/pip
+            ${{ env.pythonLocation }}/bin/*
+            ${{ env.pythonLocation }}/include
+            ${{ env.pythonLocation }}/lib/python*/site-packages/*
+            !${{ env.pythonLocation }}/bin/pip*
+            !${{ env.pythonLocation }}/lib/python*/site-packages/pipe*
+            !${{ env.pythonLocation }}/lib/python*/site-packages/setuptools*
           key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}
       - name: Setup FFmpeg
         uses: FedericoCarboni/setup-ffmpeg@v1


### PR DESCRIPTION
The scheduled runs over the weekend failed while creating the environment with a strange pip error, the one seen [here](https://stackoverflow.com/questions/67273590/pip-21-1-cant-import-invalidschemecombination). As linked in that post, it's actually a [caching issue](https://github.com/pypa/pip/issues/9880), and so making sure not to cache pip solves the issue.