### PR TITLE
Fix failing python 3.7 tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,23 +22,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      # based on AllenNLP's setup:
-      # https://medium.com/ai2-blog/python-caching-in-github-actions-e9452698e98d
-      - name: Cache environment
-        uses: actions/cache@v2
-        with:
-          # Cache the Python package environment, excluding pip and setuptools
-          # installed by setup-python, following
-          # https://github.com/pypa/pip/issues/9880
-          path: |
-            ~/.cache/pip
-            ${{ env.pythonLocation }}/bin/*
-            ${{ env.pythonLocation }}/include
-            ${{ env.pythonLocation }}/lib/python*/site-packages/*
-            !${{ env.pythonLocation }}/bin/pip*
-            !${{ env.pythonLocation }}/lib/python*/site-packages/pipe*
-            !${{ env.pythonLocation }}/lib/python*/site-packages/setuptools*
-          key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}
       - name: Install dependencies
         run: |
           # using the --upgrade and --upgrade-strategy eager flags ensures that

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: setup.py
       - name: Install dependencies
         run: |
           # using the --upgrade and --upgrade-strategy eager flags ensures that

--- a/.github/workflows/treebeard.yml
+++ b/.github/workflows/treebeard.yml
@@ -23,23 +23,6 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      # based on AllenNLP's setup:
-      # https://medium.com/ai2-blog/python-caching-in-github-actions-e9452698e98d
-      - name: Cache environment
-        uses: actions/cache@v2
-        with:
-          # Cache the Python package environment, excluding pip and setuptools
-          # installed by setup-python, following
-          # https://github.com/pypa/pip/issues/9880
-          path: |
-            ~/.cache/pip
-            ${{ env.pythonLocation }}/bin/*
-            ${{ env.pythonLocation }}/include
-            ${{ env.pythonLocation }}/lib/python*/site-packages/*
-            !${{ env.pythonLocation }}/bin/pip*
-            !${{ env.pythonLocation }}/lib/python*/site-packages/pipe*
-            !${{ env.pythonLocation }}/lib/python*/site-packages/setuptools*
-          key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}
       - name: Setup FFmpeg
         uses: FedericoCarboni/setup-ffmpeg@v1
       - name: Install dependencies

--- a/.github/workflows/treebeard.yml
+++ b/.github/workflows/treebeard.yml
@@ -23,6 +23,8 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: setup.py
       - name: Setup FFmpeg
         uses: FedericoCarboni/setup-ffmpeg@v1
       - name: Install dependencies


### PR DESCRIPTION
following Dylan's advice to remove the cache step (and replace it with caching from the `setup-python` action) in order to fix the failing python 3.7 tests. based on the error we were getting, he thought it likely that it was caused by an old version of `setuptools` and that the path list in our cache step looked questionable.