### PR TITLE
Torch 1.12 fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ data/ssim_analysis.mat
 data/msssim_images
 data/MAD_results
 data/imagenet1000_clsidx_to_labels.txt
+data/portilla*
 
 logs/
 train/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,6 +30,7 @@ If anything is unclear, please `open an issue <https://github.com/LabForComputat
    :maxdepth: 2
    :caption: Contents:
 
+   reproducibility
    api/modules
 
 .. toctree::

--- a/docs/reproducibility.rst
+++ b/docs/reproducibility.rst
@@ -1,0 +1,32 @@
+.. _reproduce:
+
+Reproducibility
+***************
+
+plenoptic includes several results reproduced from the literature and aims to
+facilitate reproducible research. However, we are limited by our dependencies
+and PyTorch, in particular, comes with the `caveat
+<https://pytorch.org/docs/stable/notes/randomness.html>`_ that "Completely
+reproducible results are not guaranteed across PyTorch releases, individual
+commits, or different platforms. Furthermore, results may not be reproducible
+between CPU and GPU executions, even when using identical seeds" (quote from the
+v1.12 documentation).
+
+This means that you should note the ``plenoptic`` version and the ``pytorch``
+version your synthesis used in order to guarantee reproduciblity (some versions
+of ``pytorch`` will give consistent results with each other, but it's not
+guaranteed and hard to predict). We do not believe reproducibility depends on
+the python version or any other packages. In general, the CPU and GPU will
+always give different results.
+
+We reproduce several results from the literature and validate these as part of
+our tests. We are therefore aware of the following changes that broke
+reproducibility:
+
+- PyTorch 1.8 and 1.9 give the same results, but 1.10 changes results in
+  changes, probably due to the difference in how the sub-gradient for
+  ``torch.min`` and ``torch.max`` are computed (`see this PR
+  <https://github.com/LabForComputationalVision/plenoptic/pull/96#issuecomment-973318291>`_).
+
+- PyTorch 1.12 breaks reproducibility with 1.10 and 1.11, unclear why (`see this
+  issue <https://github.com/LabForComputationalVision/plenoptic/issues/165>`_).

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -17,9 +17,10 @@ OSF_URL = {'plenoptic-test-files.tar.gz': 'q9kn8', 'ssim_images.tar.gz': 'j65tw'
            'ssim_analysis.mat': 'ndtc7', 'msssim_images.tar.gz': '5fuba', 'MAD_results.tar.gz': 'jwcsr', 
            'portilla_simoncelli_matlab_test_vectors.tar.gz':'qtn5y',
            'portilla_simoncelli_test_vectors.tar.gz': '8r2gq',
-           # synthesis gives different outputs on GPU vs CPU, so we have
-           # separate versions to test against
+           # synthesis gives different outputs on GPU vs CPU (and some pytorch
+           # versions), so we have separate versions to test against
            'portilla_simoncelli_synthesize.npz': 'a7p9r',
+           'portilla_simoncelli_synthesize_torch_v1.12.0.npz': 'gbv8e',
            'portilla_simoncelli_synthesize_gpu.npz': 'tn4y8',
            'portilla_simoncelli_scales.npz': 'xhwv3'}
 
@@ -39,7 +40,9 @@ def osf_download(filename):
                 'MAD_results.tar.gz',
                 'portilla_simoncelli_matlab_test_vectors.tar.gz',
                 'portilla_simoncelli_test_vectors.tar.gz',
-                'portilla_simoncelli_synthesize.npz'}
+                'portilla_simoncelli_synthesize.npz',
+                'portilla_simoncelli_synthesize_torch_v1.12.0.npz',
+                'portilla_simoncelli_synthesize_gpu.npz'}
         Which file to download.
 
     Returns

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -15,6 +15,7 @@ import os.path as op
 from test_metric import osf_download
 from plenoptic.simulate.canonical_computations import (gaussian1d, circular_gaussian2d)
 from conftest import DEVICE, DATA_DIR
+from packaging import version
 
 
 @pytest.fixture()
@@ -32,14 +33,37 @@ def portilla_simoncelli_test_vectors():
     return osf_download('portilla_simoncelli_test_vectors.tar.gz')
 
 
-@pytest.fixture()
-def portilla_simoncelli_synthesize():
+def get_portilla_simoncelli_synthesize_filename(torch_version=None):
+    """Helper function to get pathname.
+
+    We can't call fixtures directly (feature removed in pytest 4.0), so we use
+    this helper function to get the name, which we use in
+    tests/utils.update_ps_synthesis_test_file()
+
+    """
+    if torch_version is None:
+        # the bit after the + defines the CUDA version used (if any), which
+        # doesn't appear to be relevant for this.
+        torch_version = torch.__version__.split('+')[0]
+    # following https://stackoverflow.com/a/11887885 for how to compare version
+    # strings
+    if version.parse(torch_version) < version.parse('1.12'):
+        torch_version = ''
+    else:
+        torch_version = '_torch_v1.12.0'
     # synthesis gives differnet outputs on cpu vs gpu, so we have two different
     # versions to test against
+    name_template = 'portilla_simoncelli_synthesize{gpu}{torch_version}.npz'
     if DEVICE.type == 'cpu':
-        return osf_download('portilla_simoncelli_synthesize.npz')
+        gpu = ''
     elif DEVICE.type == 'cuda':
-        return osf_download('portilla_simoncelli_synthesize_gpu.npz')
+        gpu = '_gpu'
+    return name_template.format(gpu=gpu, torch_version=torch_version)
+
+
+@pytest.fixture()
+def portilla_simoncelli_synthesize(torch_version=None):
+    return osf_download(get_portilla_simoncelli_synthesize_filename(torch_version))
 
 
 @pytest.fixture()
@@ -257,7 +281,21 @@ class TestPortillaSimoncelli(object):
             output.squeeze(), saved.squeeze(), rtol=1e-5, atol=1e-5
         )
 
-    def test_ps_synthesis(self, portilla_simoncelli_synthesize):
+    def test_ps_synthesis(self, portilla_simoncelli_synthesize,
+                          run_test=True):
+        """Test PS texture metamer synthesis.
+
+        Parameters
+        ----------
+        portilla_simoncelli_synthesize : str
+            Path to the .npz file to test against
+        run_test : bool, optional
+            If True, we run the test, comparing the current synthesis against
+            the saved results. If False, we don't run the test, and return the
+            Metamer object instead (used when updating the file to test
+            against, as in tests/utils.update_ps_synthesis_test_file)
+
+        """
         # this tests whether the output of metamer synthesis is consistent.
         # this is probably the most likely to fail as our requirements change,
         # because if something in how torch computes its gradients changes,
@@ -299,13 +337,16 @@ class TestPortillaSimoncelli(object):
                                 coarse_to_fine='together',
                                 coarse_to_fine_kwargs=coarse_to_fine_kwargs)
 
-        np.testing.assert_allclose(
-            po.to_numpy(output).squeeze(), im_synth.squeeze(), rtol=1e-4, atol=1e-4,
-        )
+        if run_test:
+            np.testing.assert_allclose(
+                po.to_numpy(output).squeeze(), im_synth.squeeze(), rtol=1e-4, atol=1e-4,
+            )
 
-        np.testing.assert_allclose(
-            po.to_numpy(model(output)).squeeze(), rep_synth.squeeze(), rtol=1e-4, atol=1e-4
-        )
+            np.testing.assert_allclose(
+                po.to_numpy(model(output)).squeeze(), rep_synth.squeeze(), rtol=1e-4, atol=1e-4
+            )
+        else:
+            return met
 
 
     @pytest.mark.parametrize("n_scales", [1, 2, 3, 4])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -47,8 +47,10 @@ def get_portilla_simoncelli_synthesize_filename(torch_version=None):
         torch_version = torch.__version__.split('+')[0]
     # following https://stackoverflow.com/a/11887885 for how to compare version
     # strings
-    if version.parse(torch_version) < version.parse('1.12'):
+    if version.parse(torch_version) < version.parse('1.12') or DEVICE.type == 'cuda':
         torch_version = ''
+    # going from 1.11 to 1.12 only changes this synthesis output on cpu, not
+    # gpu
     else:
         torch_version = '_torch_v1.12.0'
     # synthesis gives differnet outputs on cpu vs gpu, so we have two different

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Helper functions for testing.
+"""
+import torch
+import re
+import plenoptic as po
+import pyrtools as pt
+import numpy as np
+from test_models import TestPortillaSimoncelli, get_portilla_simoncelli_synthesize_filename
+from test_metric import osf_download
+from conftest import DEVICE
+
+
+def update_ps_synthesis_test_file():
+    """Create new test file for test_models.test_ps_synthesis().
+
+    We cannot guarantee perfect reproducibility across pytorch versions, but we
+    can guarantee it within versions. Therefore, we need to periodically create
+    new files to test our synthesis outputs against. This helper function does
+    that, but note that you NEED to examine the resulting metamer manually to
+    ensure it still looks good.
+
+    After generating this file and checking it looks good, upload it to the OSF
+    plenoptic-files project: https://osf.io/ts37w/files/osfstorage
+
+    Returns
+    -------
+    met : po.synth.Metamer
+        Metamer object for inspection
+
+    """
+    # for now, we want to compare against the one that worked for pytorch version 1.11
+    ps_synth_file = osf_download(get_portilla_simoncelli_synthesize_filename('1.11'))
+
+    with np.load(ps_synth_file) as f:
+        im = f['im']
+        im_init = f['im_init']
+        im_synth = f['im_synth']
+        rep_synth = f['rep_synth']
+
+    met = TestPortillaSimoncelli().test_ps_synthesis(ps_synth_file, False)
+
+    torch_v = torch.__version__.split('+')[0]
+    file_name_parts = re.findall('(.*portilla_simoncelli_synthesize)(_gpu)?(_torch_v)?([0-9.]*).npz',
+                                 ps_synth_file)[0]
+    output_file_name = ''.join(file_name_parts[:2]) + f'_torch_v{torch_v}.npz'
+    print(f"Saving at {output_file_name}")
+    output = po.to_numpy(met.synthesized_signal).squeeze()
+    rep = po.to_numpy(met.model(met.synthesized_signal)).squeeze()
+    np.savez(output_file_name, im=im, im_init=im_init, im_synth=output,
+             rep_synth=rep)
+    fig = pt.imshow([output, im_synth], title=[f'New metamer (torch {torch_v})',
+                                               'Old metamer'])
+    fig.savefig(output_file_name.replace('.npz', '.png'))
+    return met

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -31,6 +31,7 @@ def update_ps_synthesis_test_file():
     """
     # for now, we want to compare against the one that worked for pytorch version 1.11
     ps_synth_file = osf_download(get_portilla_simoncelli_synthesize_filename('1.11'))
+    print(f'Loading from {ps_synth_file}')
 
     with np.load(ps_synth_file) as f:
         im = f['im']
@@ -49,7 +50,7 @@ def update_ps_synthesis_test_file():
     rep = po.to_numpy(met.model(met.synthesized_signal)).squeeze()
     np.savez(output_file_name, im=im, im_init=im_init, im_synth=output,
              rep_synth=rep)
-    fig = pt.imshow([output, im_synth], title=[f'New metamer (torch {torch_v})',
-                                               'Old metamer'])
+    fig = pt.imshow([output, im_synth.squeeze()],
+                    title=[f'New metamer (torch {torch_v})', 'Old metamer'])
     fig.savefig(output_file_name.replace('.npz', '.png'))
     return met


### PR DESCRIPTION
This should fix #165. I added a version of the PS texture metamer synthesis file to compare against for v1.12.0 and above. Turns out that this change only affects the CPU, not GPU. Also made it so we test against the right version, based on torch version.

Also adds a small reprodubility page to the docs before merging (#144 )