### PR TITLE
Make the installs for the GPU and CPU tests the same

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install dependencies
         # nbclient 0.5.5 is the first version that includes jupyter execute
         run: |
-          pip install --upgrade --upgrade-strategy eager -e .
+          pip install --upgrade --upgrade-strategy eager .
           pip install jupyter ipywidgets
           pip install "nbclient>=0.5.5"
       - name: Run notebooks
@@ -86,7 +86,7 @@ jobs:
           # using the --upgrade and --upgrade-strategy eager flags ensures that
           # pip will always install the latest allowed version of all
           # dependencies, to make sure the cache doesn't go stale
-          pip install --upgrade --upgrade-strategy eager -e .
+          pip install --upgrade --upgrade-strategy eager .
           pip install --upgrade --upgrade-strategy eager pytest-cov
 
       - name: Run tests with pytest

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -15,4 +15,4 @@ RUN apt-get update && \
     rm -rf /var/cache/apt/* /var/lib/apt/lists/*
 
 COPY requirements.txt /tmp/
-RUN pip3 install -r /tmp/requirements.txt
+RUN pip3 install --upgrade --upgrade-strategy eager -r /tmp/requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         "plenoptic.synthesize",
         "plenoptic.tools",
     ],
-    package_data={'plenoptic.metric': ['*.npy']},
+    package_data={'plenoptic.metric': ['DN_sigmas.npy', 'DN_filts.npy']},
     install_requires=readlines('jenkins/requirements.txt'),
     tests="tests",
 )

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         "plenoptic.synthesize",
         "plenoptic.tools",
     ],
+    package_data={'': ['plenoptic/metric/*.npy']},
     install_requires=readlines('jenkins/requirements.txt'),
     tests="tests",
 )

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         "plenoptic.synthesize",
         "plenoptic.tools",
     ],
-    package_data={'': ['plenoptic/metric/*.npy']},
+    package_data={'plenoptic.metric': ['*.npy']},
     install_requires=readlines('jenkins/requirements.txt'),
     tests="tests",
 )


### PR DESCRIPTION
Small changes were necessary to make the install for the GPU-tests on jenkins have the same flags as for the CPU tests on Github actions.

This was a problem because the cached dependencies used in the GPU tests were getting out of sync (the matplotlib version required a newer numpy version, in #177 ), which the `--upgrade` flag should fix. (Note that we install the requirements using `requirements.txt` in the Dockerfile, which means they'll all get cached. The actions of the Jenkinsfile don't get cached, but that has the same `pip install .` that the CPU tests use. Effectively, we've just split it into two steps)

Additionally, this PR removes the `-e` flag from the CPU tests, since we should be testing the production install.