### PR TITLE
Remove dill

### DIFF
--- a/jenkins/requirements.txt
+++ b/jenkins/requirements.txt
@@ -9,5 +9,4 @@ requests>=2.21
 imageio>=2.5
 pytest>=5.1.2
 scikit-image>=0.15.0
-dill
 einops>=0.3.0

--- a/plenoptic/synthesize/mad_competition.py
+++ b/plenoptic/synthesize/mad_competition.py
@@ -39,10 +39,16 @@ class MADCompetition(Synthesis):
         match. If this is not a tensor, we try to cast it as one.
     synthesis_metric :
         The metric whose value you wish to minimize or maximize, which takes
-        two tensors and returns a scalar.
+        two tensors and returns a scalar. Because of the limitations of pickle,
+        you cannot use a lambda function for this if you wish to save the
+        Metamer object (i.e., it must be one of our built-in functions or
+        defined using a `def` statement)
     fixed_metric :
         The metric whose value you wish to keep fixed, which takes two tensors
-        and returns a scalar.
+        and returns a scalar. Because of the limitations of pickle, you cannot
+        use a lambda function for this if you wish to save the Metamer object
+        (i.e., it must be one of our built-in functions or defined using a
+        `def` statement)
     synthesis_target :
         Whether you wish to minimize or maximize ``synthesis_metric``.
     initial_noise :

--- a/plenoptic/synthesize/metamer.py
+++ b/plenoptic/synthesize/metamer.py
@@ -36,8 +36,11 @@ class Metamer(Synthesis):
     model :
         A visual model, see `MAD_Competition` notebook for more details
     loss_function :
-        the loss function to use to compare the representations of the
-        models in order to determine their loss.
+        the loss function to use to compare the representations of the models
+        in order to determine their loss. Because of the limitations of pickle,
+        you cannot use a lambda function for this if you wish to save the
+        Metamer object (i.e., it must be one of our built-in functions or
+        defined using a `def` statement)
     range_penalty_lambda :
         Lambda to multiply by range penalty and add to loss.
     allowable_range :

--- a/plenoptic/synthesize/synthesis.py
+++ b/plenoptic/synthesize/synthesis.py
@@ -2,7 +2,6 @@
 import abc
 import warnings
 import torch
-import dill
 from typing import Union, List
 
 
@@ -55,7 +54,7 @@ class Synthesis(metaclass=abc.ABCMeta):
             if isinstance(attr, torch.Tensor):
                 attr = attr.detach()
             save_dict[k] = attr
-        torch.save(save_dict, file_path, pickle_module=dill)
+        torch.save(save_dict, file_path)
 
     def load(self, file_path: str,
              map_location: Union[str, None] = None,
@@ -99,7 +98,7 @@ class Synthesis(metaclass=abc.ABCMeta):
             ``torch.load``, see that function's docstring for details.
 
         """
-        tmp_dict = torch.load(file_path, pickle_module=dill,
+        tmp_dict = torch.load(file_path,
                               map_location=map_location,
                               **pickle_load_args)
         if map_location is not None:

--- a/tests/test_mad.py
+++ b/tests/test_mad.py
@@ -12,6 +12,23 @@ import os.path as op
 from conftest import DEVICE, DATA_DIR, get_model
 import numpy as np
 
+
+# in order for pickling to work with functions, they must be defined at top of
+# module: https://stackoverflow.com/a/36995008
+def rgb_mse(*args):
+    return po.metric.mse(*args).mean()
+
+
+def rgb_l2_norm(*args):
+    return po.tools.optim.l2_norm(*args).mean()
+
+
+# MAD requires metrics are *dis*-similarity metrics, so that they
+# return 0 if two images are identical (SSIM normally returns 1)
+def dis_ssim(*args):
+    return (1 - po.metric.ssim(*args)).mean()
+
+
 class TestMAD(object):
 
     @pytest.mark.parametrize('target', ['min', 'max'])
@@ -20,9 +37,9 @@ class TestMAD(object):
     def test_basic(self, curie_img, target, model_order, store_progress):
         if model_order == 'mse-ssim':
             model = po.metric.mse
-            model2 = lambda *args: 1 - po.metric.ssim(*args)
+            model2 = dis_ssim
         elif model_order == 'ssim-mse':
-            model = lambda *args: 1 - po.metric.ssim(*args)
+            model = dis_ssim
             model2 = po.metric.mse
         mad = po.synth.MADCompetition(curie_img, model, model2, target)
         mad.synthesize(max_iter=5, store_progress=store_progress)
@@ -34,17 +51,12 @@ class TestMAD(object):
     @pytest.mark.parametrize('model', ['ColorModel'], indirect=True)
     def test_save_load(self, curie_img, fail, rgb, model, tmp_path):
         # this works with either rgb or grayscale images
-        def metric(*args):
-            return po.metric.mse(*args).mean()
+        metric = rgb_mse
         if rgb:
             curie_img = curie_img.repeat(1, 3, 1, 1)
-            def metric2(x1, x2):
-                return po.metric.mse(model(x1), model(x2)).mean()
-        # MAD requires metrics are *dis*-similarity metrics, so that they
-        # return 0 if two images are identical (SSIM normally returns 1)
+            metric2 = rgb_l2_norm
         else:
-            def metric2(*args):
-                return 1-po.metric.ssim(*args)
+            metric2 = dis_ssim
         target = 'min'
         mad = po.synth.MADCompetition(curie_img, metric, metric2, target)
         mad.synthesize(max_iter=4, store_progress=True)
@@ -56,12 +68,10 @@ class TestMAD(object):
                 # this works with either rgb or grayscale images (though note
                 # that SSIM just operates on each RGB channel independently,
                 # which is probably not the right thing to do)
-                def metric(x1, x2):
-                    return 2*(1 - po.metric.ssim(x1, x2)).mean()
+                metric = dis_ssim
             elif fail == 'metric2':
                 # this works with either rgb or grayscale images
-                def metric2(*args):
-                    return po.metric.mse(*args).mean()
+                metric2 = rgb_mse
             elif fail == 'target':
                 target = 'max'
             mad_copy = po.synth.MADCompetition(curie_img, metric, metric2, target)

--- a/tests/test_metamers.py
+++ b/tests/test_metamers.py
@@ -40,8 +40,7 @@ class TestMetamers(object):
             elif fail == 'model':
                 model = po.simul.Gaussian(30).to(DEVICE)
             elif fail == 'loss':
-                def loss(*args, **kwargs):
-                    return 1
+                loss = po.metric.ssim
             elif fail == 'range_penalty':
                 range_penalty = .5
             met_copy = po.synth.Metamer(einstein_img, model,

--- a/tests/test_metamers.py
+++ b/tests/test_metamers.py
@@ -14,7 +14,7 @@ from conftest import DEVICE
 class TestMetamers(object):
 
     @pytest.mark.parametrize('model', ['frontend.LinearNonlinear'], indirect=True)
-    @pytest.mark.parametrize('loss_func', ['mse', 'l2'])
+    @pytest.mark.parametrize('loss_func', ['mse', 'l2', 'custom'])
     @pytest.mark.parametrize('fail', [False, 'img', 'model', 'loss', 'range_penalty'])
     @pytest.mark.parametrize('range_penalty', [.1, 0])
     def test_metamer_save_load(self, einstein_img, model, loss_func, fail, range_penalty, tmp_path):
@@ -22,6 +22,9 @@ class TestMetamers(object):
             loss = po.tools.optim.mse
         elif loss_func == 'l2':
             loss = po.tools.optim.l2_norm
+        elif loss_func == 'custom':
+            def loss(x1, x2):
+                return (x1-x2).sum()
         met = po.synth.Metamer(einstein_img, model, loss_function=loss,
                                range_penalty_lambda=range_penalty)
         met.synthesize(max_iter=4, store_progress=True)
@@ -32,7 +35,8 @@ class TestMetamers(object):
             elif fail == 'model':
                 model = po.simul.Gaussian(30).to(DEVICE)
             elif fail == 'loss':
-                loss = lambda *args, **kwargs: 1
+                def loss(*args, **kwargs):
+                    return 1
             elif fail == 'range_penalty':
                 range_penalty = .5
             met_copy = po.synth.Metamer(einstein_img, model,

--- a/tests/test_metamers.py
+++ b/tests/test_metamers.py
@@ -11,6 +11,12 @@ import pytest
 from conftest import DEVICE
 
 
+# in order for pickling to work with functions, they must be defined at top of
+# module: https://stackoverflow.com/a/36995008
+def custom_loss(x1, x2):
+    return (x1-x2).sum()
+
+
 class TestMetamers(object):
 
     @pytest.mark.parametrize('model', ['frontend.LinearNonlinear'], indirect=True)
@@ -23,8 +29,7 @@ class TestMetamers(object):
         elif loss_func == 'l2':
             loss = po.tools.optim.l2_norm
         elif loss_func == 'custom':
-            def loss(x1, x2):
-                return (x1-x2).sum()
+            loss = custom_loss
         met = po.synth.Metamer(einstein_img, model, loss_function=loss,
                                range_penalty_lambda=range_penalty)
         met.synthesize(max_iter=4, store_progress=True)


### PR DESCRIPTION
Our most recent test were failing, due to a problem with `dill`, which is a library that allows for pickling of more python callables. The most recent several versions of `dill` (at least `0.3.4` through `0.3.6`) give an error when loading a `Metamer` or `MADCompetition` object with the most recent version of `torch` (`1.13`). The error message was completely opaque to me (`AttributeError: Can't get attribute 'NoneType' on <module 'builtins' (built-in)>`) and I couldn't find any relevant info.

So, I'm removing `dill` as a requirement and switching back to using the built-in pickling. The reason I had added `dill` was to allow the pickling of arbitrary callables, but we've since limited what we expect (in particular, I used to allow `Metamer` to accept any callable as a model, but we've since changed that to require it to be an object, not a function). The only limitation I could find now when swapping dill back for the built-in was the saving of lambdas, but, importantly, custom functions still work as long as they're explicitly defined with a `def` block  (and [at the top level of a module](https://stackoverflow.com/a/36995008), though that's probably less relevant for users). So I've updated the tests and docstrings appropriately.