### PR TITLE
Adds citation guide, minor improvements to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 [![Documentation Status](https://readthedocs.org/projects/plenoptic/badge/?version=latest)](https://plenoptic.readthedocs.io/en/latest/?badge=latest)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3995057.svg)](https://doi.org/10.5281/zenodo.3995057)
 [![codecov](https://codecov.io/gh/LabForComputationalVision/plenoptic/branch/main/graph/badge.svg?token=EDtl5kqXKA)](https://codecov.io/gh/LabForComputationalVision/plenoptic)
-[![Tutorials Status](https://github.com/LabForComputationalVision/plenoptic/workflows/tutorials/badge.svg)](https://github.com/LabForComputationalVision/plenoptic/actions?query=workflow%3Atutorials)
 [![Binder](http://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/LabForComputationalVision/plenoptic/1.0.1?filepath=examples)
 
 ![](docs/images/plenoptic_logo_wide.svg)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ documentation](https://matplotlib.org/stable/api/animation_api.html#writer-class
 for more details. In order convert them to HTML5 for viewing (and thus, to view
 in a jupyter notebook), you'll need [ffmpeg](https://ffmpeg.org/download.html)
 installed and on your path as well. Depending on your system, this might already
-be installed.
+be installed, but if not, the easiest way is probably through [conda]
+(https://anaconda.org/conda-forge/ffmpeg): `conda install -c conda-forge
+ffmpeg`.
 
 To change the backend, run `matplotlib.rcParams['animation.writer'] = writer`
 before calling any of the animate functions. If you try to set that `rcParam`

--- a/README.md
+++ b/README.md
@@ -128,6 +128,13 @@ We communicate via several channels on Github:
 
 In all cases, please follow our [code of conduct](CODE_OF_CONDUCT.md).
 
+## Citing us
+
+If you use `plenoptic` in a published academic article or presentation, please
+cite us! See the [citation
+guide](https://pyrtools.readthedocs.io/en/latest/citation.html) for more
+details.
+
 ## Support
 
 This package is supported by the Simons Foundation Flatiron Institute's Center

--- a/docs/citation.rst
+++ b/docs/citation.rst
@@ -1,0 +1,28 @@
+.. _citation:
+
+Citation Guide
+**************
+
+If you use ``plenoptic`` in a published piece of academic work, please cite
+[VSS2023]_ (and check this guide again before publishing, as we are planning on
+having a paper to cite instead of the current presentation).
+
+Additionally, please additionally cite the following paper(s) depending on which
+component you use:
+
+-  :class:`plenoptic.synthesize.metamer.Metamer`: or :class:`plenoptic.synthesize.metamer.MetamerCTF`: [Portilla2000]_.
+- :class:`plenoptic.synthesize.mad_competition.MADCompetition`: [Wang2008]_.
+- :class:`plenoptic.synthesize.eigendistortion.Eigendistortion`: [Berardino2017]_.
+- :class:`plenoptic.synthesize.geodesic.Geodesic`: [Henaff2016]_.
+- :class:`plenoptic.simulate.canonical_computations.steerable_pyramid_freq.SteerablePyramidFreq`: [Simoncelli1992]_.
+- :class:`plenoptic.simulate.models.portilla_simoncelli.PortillaSimoncelli`: [Portilla2000]_.
+- :class:`plenoptic.simulate.models.frontend` (any model): [Berardino2017]_.
+- :class:`plenoptic.metric.perceptual_distance.ssim` or :class:`plenoptic.metric.perceptual_distance.ssim_map`: [Wang2004]_ if ``weighted=False``, [Wang2008]_ if ``weighted=True``.
+- :class:`plenoptic.metric.perceptual_distance.ms_ssim`: [Wang2003]_.
+- :class:`plenoptic.metric.perceptual_distance.nlpd`: [Laparra2017]_.
+
+.. [VSS2023] Lyndon Duong, Kathryn Bonnen, William Broderick, Pierre-Étienne
+             Fiquet, Nikhil Parthasarathy, Thomas Yerxa, Xinyuan Zhao, Eero
+             Simoncelli; Plenoptic: A platform for synthesizing model-optimized
+             visual stimuli. Journal of Vision 2023;23(9):5822.
+             https://doi.org/10.1167/jov.23.9.5822.

--- a/docs/citation.rst
+++ b/docs/citation.rst
@@ -14,12 +14,21 @@ component you use:
 - :class:`plenoptic.synthesize.mad_competition.MADCompetition`: [Wang2008]_.
 - :class:`plenoptic.synthesize.eigendistortion.Eigendistortion`: [Berardino2017]_.
 - :class:`plenoptic.synthesize.geodesic.Geodesic`: [Henaff2016]_.
-- :class:`plenoptic.simulate.canonical_computations.steerable_pyramid_freq.SteerablePyramidFreq`: [Simoncelli1992]_.
+- :class:`plenoptic.simulate.canonical_computations.steerable_pyramid_freq.SteerablePyramidFreq`: [Simoncelli1995]_ ([Simoncelli1992]_ contains a longer discussion about the motivation and the logic, while [Simoncelli1995]_ describes the implementation that is used here).
 - :class:`plenoptic.simulate.models.portilla_simoncelli.PortillaSimoncelli`: [Portilla2000]_.
 - :class:`plenoptic.simulate.models.frontend` (any model): [Berardino2017]_.
 - :class:`plenoptic.metric.perceptual_distance.ssim` or :class:`plenoptic.metric.perceptual_distance.ssim_map`: [Wang2004]_ if ``weighted=False``, [Wang2008]_ if ``weighted=True``.
 - :class:`plenoptic.metric.perceptual_distance.ms_ssim`: [Wang2003]_.
 - :class:`plenoptic.metric.perceptual_distance.nlpd`: [Laparra2017]_.
+
+Note that, the citations given above define the application of the relevant idea
+("metamers") to computational models of the visual system that are instantiated
+in the algorithms found in ``plenoptic``, but that, for the most part, these
+general concepts were not developed by the developers of ``plenoptic`` or the
+Simoncelli lab and are, in general, much older -- the idea of metamers goes all
+the way back to [Helmholtz1852]_! The papers above generally provide some
+discussion of this history and can point you to further reading, if you are
+interested.
 
 .. [VSS2023] Lyndon Duong, Kathryn Bonnen, William Broderick, Pierre-Étienne
              Fiquet, Nikhil Parthasarathy, Thomas Yerxa, Xinyuan Zhao, Eero

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,9 @@ extensions = [
     'matplotlib.sphinxext.plot_directive',
     'matplotlib.sphinxext.mathmpl',
     'sphinx.ext.autodoc',
-    'sphinx_autodoc_typehints'
+    'sphinx_autodoc_typehints',
+    'sphinx.ext.intersphinx',
+    'sphinx_copybutton',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -185,4 +185,4 @@ epub_exclude_files = ['search.html']
 
 
 # -- Extension configuration -------------------------------------------------
-apidoc_module_dir = "../plenoptic"
+apidoc_module_dir = "../src/plenoptic"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,11 +9,11 @@
 .. |build| image:: https://github.com/LabForComputationalVision/plenoptic/workflows/build/badge.svg
 		     :target: https://github.com/LabForComputationalVision/plenoptic/actions?query=workflow%3Abuild
 
-.. |tutorials| image:: https://github.com/LabForComputationalVision/plenoptic/workflows/tutorials/badge.svg
-		         :target: https://github.com/LabForComputationalVision/plenoptic/actions?query=workflow%3Atutorials
-
 .. |zenodo| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.3995057.svg
             :target: https://doi.org/10.5281/zenodo.3995057
+
+.. |codecov| image:: https://codecov.io/gh/LabForComputationalVision/plenoptic/branch/main/graph/badge.svg?token=EDtl5kqXKA
+             :target: https://codecov.io/gh/LabForComputationalVision/plenoptic)
 
 .. |binder| image:: https://mybinder.org/badge_logo.svg
 		    :target: https://mybinder.org/v2/gh/LabForComputationalVision/plenoptic/1.0.1?filepath=examples
@@ -27,7 +27,7 @@
 plenoptic
 *********
 
-|pypi-shield| |license-shield| |python-version-shield| |build| |tutorials| |zenodo| |binder|
+|pypi-shield| |license-shield| |python-version-shield| |build| |zenodo| |codecov| |binder|
 
 
 .. image:: images/plenoptic_logo_wide.svg

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -163,6 +163,12 @@ We communicate via several channels on Github:
 In all cases, we request that you respect our `code of conduct
 <https://github.com/LabForComputationalVision/plenoptic/blob/main/CODE_OF_CONDUCT.md>`_.
 
+Citing us
+---------
+
+If you use ``plenoptic`` in a published academic article or presentation, please
+cite us! See the :ref:`citation` for more details.
+
 .. toctree::
    :titlesonly:
    :caption: Basic concepts
@@ -172,6 +178,7 @@ In all cases, we request that you respect our `code of conduct
    conceptual_intro
    models
    tutorials/*
+   citation
 
 .. toctree::
    :titlesonly:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,7 +13,7 @@
             :target: https://doi.org/10.5281/zenodo.3995057
 
 .. |codecov| image:: https://codecov.io/gh/LabForComputationalVision/plenoptic/branch/main/graph/badge.svg?token=EDtl5kqXKA
-             :target: https://codecov.io/gh/LabForComputationalVision/plenoptic)
+             :target: https://codecov.io/gh/LabForComputationalVision/plenoptic
 
 .. |binder| image:: https://mybinder.org/badge_logo.svg
 		    :target: https://mybinder.org/v2/gh/LabForComputationalVision/plenoptic/1.0.1?filepath=examples

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -68,7 +68,10 @@ available for saving the animations to file (see `matplotlib documentation
 ).
 To convert them to HTML5 for viewing (for example, in a
 jupyter notebook), you'll need `ffmpeg <https://ffmpeg.org/download.html>`_
-installed. 
+installed. Depending on your system, this might already
+be installed, but if not, the easiest way is probably through `conda
+<https://anaconda.org/conda-forge/ffmpeg>`_: ``conda install -c conda-forge
+ffmpeg``.
 To change the backend, run ``matplotlib.rcParams['animation.writer'] = writer``
 before calling any of the animate functions. If you try to set that ``rcParam``
 with a random string, ``matplotlib`` will list the available choices.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -122,14 +122,17 @@ Synthesis methods
 Models, Metrics, and Model Components
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- Steerable pyramid, [Simoncelli1992]_, a multi-scale oriented image
-  decomposition. Images are decomposed with a family of oriented filters, localized in space
-  and frequency, similar to the "Gabor functions" commonly used to model receptive fields in primary visual cortex.  
-  The critical difference is that the pyramid organizes these filters so as to effeciently cover the 4D space of 
-  (x,y) positions, orientations, and scales, enabling efficient interpolation and interpretation 
-  (`further info <https://www.cns.nyu.edu/~eero/STEERPYR/>`_ ). See the `pyrtools documentation
+- Steerable pyramid, [Simoncelli1992]_ and [Simoncelli1995]_, a multi-scale
+  oriented image decomposition. Images are decomposed with a family of oriented
+  filters, localized in space and frequency, similar to the "Gabor functions"
+  commonly used to model receptive fields in primary visual cortex. The critical
+  difference is that the pyramid organizes these filters so as to effeciently
+  cover the 4D space of (x,y) positions, orientations, and scales, enabling
+  efficient interpolation and interpretation (`further info
+  <https://www.cns.nyu.edu/~eero/STEERPYR/>`_ ). See the `pyrtools documentation
   <https://pyrtools.readthedocs.io/en/latest/index.html>`_ for more details on
-  python tools for image pyramids in general and the steerable pyramid in particular.
+  python tools for image pyramids in general and the steerable pyramid in
+  particular.
 - Portilla-Simoncelli texture model, [Portilla2000]_, which computes a set of image statistics
   that capture the appearance of visual textures (`further info <https://www.cns.nyu.edu/~lcv/texture/>`_).
 - Structural Similarity Index (SSIM), [Wang2004]_, is a perceptual similarity
@@ -247,6 +250,9 @@ cite us! See the :ref:`citation` for more details.
    Goris. Primary visual cortex straightens natural video trajectories Nature
    Communications, vol.12(5982), Oct 2021.
    https://www.cns.nyu.edu/pub/lcv/henaff20-reprint.pdf
+.. [Simoncelli1992] Simoncelli, E. P., Freeman, W. T., Adelson, E. H., &
+   Heeger, D. J. (1992). Shiftable Multi-Scale Transforms. IEEE Trans.
+   Information Theory, 38(2), 587–607. http://dx.doi.org/10.1109/18.119725
 .. [Simoncelli1995] Simoncelli, E. P., & Freeman, W. T. (1995). The steerable
    pyramid: A flexible architecture for multi-scale derivative computation. In ,
    Proc 2nd IEEE Int'l Conf on Image Proc (ICIP) (pp. 444–447). Washington, DC:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,9 +52,7 @@ Getting started
 Installation
 ^^^^^^^^^^^^
 
-.. highlight:: bash
-
-The best way to install ``plenoptic`` is via ``pip``.
+The best way to install ``plenoptic`` is via ``pip``::
 
 $ pip install plenoptic
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -32,10 +32,12 @@ ffmpeg and videos
 Several methods in this package generate videos. There are several backends
 possible for saving the animations to file, see `matplotlib documentation
 <https://matplotlib.org/stable/api/animation_api.html#writer-classes>`_ for more
-details. In order convert them to HTML5 for viewing (and thus, to view in a
+details. In order to convert them to HTML5 for viewing (and thus, to view in a
 jupyter notebook), you'll need `ffmpeg <https://ffmpeg.org/download.html>`_
 installed and on your path as well. Depending on your system, this might already
-be installed.
+be installed, but if not, the easiest way is probably through `conda
+<https://anaconda.org/conda-forge/ffmpeg>`_: ``conda install -c conda-forge
+ffmpeg``.
 
 To change the backend, run ``matplotlib.rcParams['animation.writer'] = writer``
 before calling any of the animate functions. If you try to set that ``rcParam``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ docs = [
      'nbsphinx_link',
      'sphinxcontrib-apidoc',
      'sphinx-autodoc-typehints',
+     'sphinx-copybutton',
 ]
 
 dev = [


### PR DESCRIPTION
This PR:
- Adds citation guide
- Removes old tutorial badge (now, tutorials run as part of `build` action)
- Corrects `apidoc_module_dir` so modules are appropriately built in documentation
- Adds codecov badge to docs
- Fixes an issue with formatting on install instructions on index.rst
- Adds instructions for `ffmpeg` install
- Adds some useful sphinx extensions