### PR TITLE
Readthedocs hotfix

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,7 +17,6 @@ sphinx:
 
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:
-  - pdf
   - htmlzip
 
 python:

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ In all cases, please follow our [code of conduct](CODE_OF_CONDUCT.md).
 
 If you use `plenoptic` in a published academic article or presentation, please
 cite us! See the [citation
-guide](https://pyrtools.readthedocs.io/en/latest/citation.html) for more
+guide](https://plenoptic.readthedocs.io/en/latest/citation.html) for more
 details.
 
 ## Support


### PR DESCRIPTION
Readthedocs wasn't building from main because of an issue with pdf creation. Since that's not that useful, removing it.

Additionally, fixes link to citation guide in readme