### PR TITLE
Small documentation-related fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,17 @@ jobs:
         for file in docs/tutorials/*/*nblink; do let "n_nblink+=1"; done;
         n_ipynb=0; for file in examples/*ipynb; do let "n_ipynb+=1"; done;
         if [[ $n_nblink != $n_ipynb ]]; then exit 1; fi;
+  check_urls:
+    runs-on: ubuntu-latest
+    name: Check all urls are valid
+    steps:
+    - uses: actions/checkout@v3
+    - uses: urlstechie/urlchecker-action@0.0.34
+      with:
+        file_types: .md,.py,.rst,.ipynb
+        print_all: false
+        timeout: 5
+        retry_count: 3
 
   check:
     if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,6 @@ jobs:
     needs:
     - notebooks
     - tests
-    - check_urls
     - all_tutorials_in_docs
     - no_extra_nblinks
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,9 @@ jobs:
     needs:
     - notebooks
     - tests
+    - check_urls
+    - all_tutorials_in_docs
+    - no_extra_nblinks
     runs-on: ubuntu-latest
     steps:
     - name: Decide whether all tests and notebooks succeeded

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,7 +201,7 @@ metamer instances run for. We do this using
 
 - Add a cell to the top of the notebook (under the import cell), add the
   parameter tag (see [papermill
-  documentation]https://papermill.readthedocs.io/en/latest/usage-parameterize.html()),
+  documentation](https://papermill.readthedocs.io/en/latest/usage-parameterize.html),
   and create a variable for each synthesis duration (e.g., `vgg16_synth_max_iter
   = 1000`).
 - Where synthesis is called later in the notebook, replace the number with the
@@ -309,7 +309,7 @@ that means nothing to you, don't worry!
 
 Documentation comes in two types: `.rst` files (reST, the markup language used
 by Sphinx, see
-[here](https://www.sphinx-doc.org/en/main/usage/restructuredtext/basics.html)
+[here](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html)
 for a primer), which contain only text (including math) and images, and `.ipynb`
 files (Jupyter notebooks), which also contain code.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -212,7 +212,7 @@ cite us! See the :ref:`citation` for more details.
    synthesis
    tips
    reproducibility
-   Modules <api/modules>
+   API Documentation <api/modules>
    tutorials/advanced/*
 
 .. [Portilla2000] Portilla, J., & Simoncelli, E. P. (2000). A parametric texture


### PR DESCRIPTION
- Rename "modules" to "API Documentation" in docs, which is more stanard
- Adds urlchecker action, to make sure all our urls are valid