### PR TITLE
Switch models to using register_buffers

### DIFF
--- a/src/plenoptic/simulate/models/naive.py
+++ b/src/plenoptic/simulate/models/naive.py
@@ -129,7 +129,7 @@ class Gaussian(nn.Module):
         self.out_channels = out_channels
 
         self.cache_filt = cache_filt
-        self._filt = None
+        self.register_buffer('_filt', None)
 
     @property
     def filt(self):
@@ -139,7 +139,7 @@ class Gaussian(nn.Module):
             filt = circular_gaussian2d(self.kernel_size, self.std, self.out_channels)
 
             if self.cache_filt:
-                self._filt = filt
+                self.register_buffer('_filt', filt)
             return filt
 
     def forward(self, x: Tensor, **conv2d_kwargs) -> Tensor:
@@ -235,7 +235,7 @@ class CenterSurround(nn.Module):
         self.pad_mode = pad_mode
 
         self.cache_filt = cache_filt
-        self._filt = None
+        self.register_buffer('_filt', None)
 
     @property
     def filt(self) -> Tensor:
@@ -256,7 +256,7 @@ class CenterSurround(nn.Module):
             filt = on_amp * (sign * (filt_center - filt_surround))
 
             if self.cache_filt:
-                self._filt = filt
+                self.register_buffer('_filt', filt)
         return filt
 
     def _clamp_surround_std(self):

--- a/src/plenoptic/simulate/models/portilla_simoncelli.py
+++ b/src/plenoptic/simulate/models/portilla_simoncelli.py
@@ -88,15 +88,15 @@ class PortillaSimoncelli(nn.Module):
             height=0, order=1,
             tight_frame=False
         )
-        for i in range(n_scales):
-            pyr = SteerablePyramidFreq(
+        self.unoriented_band_pyrs = torch.nn.ModuleList([
+            SteerablePyramidFreq(
                 getattr(self.pyr, f'_himasks_scale_{i}').shape[-2:],
                 height=1,
                 order=self.n_orientations - 1,
                 is_complex=False,
                 tight_frame=False,
-            )
-            setattr(self, f'unoriented_band_pyrs_scale_{i}', pyr)
+            ) for i in range(n_scales)
+        ])
 
         self.use_true_correlations = use_true_correlations
         self.scales = (
@@ -666,7 +666,7 @@ class PortillaSimoncelli(nn.Module):
             reconstructed_image = reconstructed_image.unsqueeze(0).unsqueeze(0)
 
             # reconstruct the unoriented band for this scale
-            unoriented_band_pyr = getattr(self, f'unoriented_band_pyrs_scale_{this_scale}')
+            unoriented_band_pyr = self.unoriented_band_pyrs[this_scale]
             unoriented_pyr_coeffs = unoriented_band_pyr.forward(reconstructed_image)
             for ii in range(self.n_orientations):
                 unoriented_pyr_coeffs[(0, ii)] = (

--- a/src/plenoptic/tools/validate.py
+++ b/src/plenoptic/tools/validate.py
@@ -287,7 +287,10 @@ def validate_metric(metric: Union[torch.nn.Module, Callable[[Tensor, Tensor], Te
 
 
 def remove_grad(model: torch.nn.Module):
-    """Detach all parameters of model (in place)."""
+    """Detach all parameters and buffers of model (in place)."""
     for p in model.parameters():
+        if p.requires_grad:
+            p.detach_()
+    for p in model.buffers():
         if p.requires_grad:
             p.detach_()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,6 +68,16 @@ def get_model(name):
                 return pyr_tensor
         # setting height=1 and # order=1 limits the size
         return spyr((256, 256), height=1, order=1).to(DEVICE)
+    elif name == "LPyr":
+        # in order to get a tensor back, need to wrap laplacian pyramid so that
+        # we can flatten the output. in practice, not the best way to use this
+        class lpyr(po.simul.LaplacianPyramid):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+            def forward(self, *args, **kwargs):
+                coeffs = super().forward(*args, **kwargs)
+                return torch.cat([c.flatten(-2) for c in coeffs], -1)
+        return lpyr().to(DEVICE)
     elif name == 'Identity':
         return po.simul.models.naive.Identity().to(DEVICE)
     elif name == 'NLP':
@@ -121,6 +131,8 @@ def get_model(name):
         model = VideoModel((31, 31), pretrained=True, cache_filt=True).to(DEVICE)
         po.tools.remove_grad(model)
         return model
+    elif name == "PortillaSimoncelli":
+        return po.simul.PortillaSimoncelli((256, 256))
 
 
 @pytest.fixture(scope='package')

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -72,6 +72,35 @@ def portilla_simoncelli_scales():
     return osf_download('portilla_simoncelli_scales.npz')
 
 
+def template_test_cuda(model, img):
+    model.cuda()
+    model(img)
+    # make sure it ends on same device it started, since it might be a fixture
+    model.to(DEVICE)
+
+def template_test_cpu_and_back(model, img):
+    model.cpu()
+    model.cuda()
+    model(img)
+    # make sure it ends on same device it started, since it might be a fixture
+    model.to(DEVICE)
+
+def template_test_cuda_and_back(model, img):
+    model.cuda()
+    model.cpu()
+    model(img.cpu())
+    # make sure it ends on same device it started, since it might be a fixture
+    img.to(DEVICE)
+    model.to(DEVICE)
+
+def template_test_cpu(model, img):
+    model.cpu()
+    model(img.cpu())
+    # make sure it ends on same device it started, since it might be a fixture
+    img.to(DEVICE)
+    model.to(DEVICE)
+
+
 class TestNonLinearities(object):
     def test_rectangular_to_polar_dict(self, basic_stim):
         spc = po.simul.SteerablePyramidFreq(basic_stim.shape[-2:], height=5,
@@ -133,31 +162,21 @@ class TestLaplacianPyramid(object):
     @pytest.mark.skipif(DEVICE.type == 'cpu', reason="Can only test on cuda")
     def test_cuda(self, einstein_img):
         lpyr = po.simul.LaplacianPyramid()
-        lpyr.cuda()
-        lpyr(einstein_img)
+        template_test_cuda(lpyr, einstein_img)
 
     @pytest.mark.skipif(DEVICE.type == 'cpu', reason="Can only test on cuda")
     def test_cpu_and_back(self, einstein_img):
         lpyr = po.simul.LaplacianPyramid()
-        lpyr.cpu()
-        lpyr.cuda()
-        lpyr(einstein_img)
+        template_test_cpu_and_back(lpyr, einstein_img)
 
     @pytest.mark.skipif(DEVICE.type == 'cpu', reason="Can only test on cuda")
     def test_cuda_and_back(self, einstein_img):
         lpyr = po.simul.LaplacianPyramid()
-        lpyr.cuda()
-        lpyr.cpu()
-        lpyr(einstein_img.cpu())
-        # make sure it ends on same device it started, since it's a fixture
-        einstein_img.to(DEVICE)
+        template_test_cuda_and_back(lpyr, einstein_img)
 
     def test_cpu(self, einstein_img):
         lpyr = po.simul.LaplacianPyramid()
-        lpyr.cpu()
-        lpyr(einstein_img.cpu())
-        # make sure it ends on same device it started, since it's a fixture
-        einstein_img.to(DEVICE)
+        template_test_cpu(lpyr, einstein_img)
 
 class TestFrontEnd:
 
@@ -199,37 +218,21 @@ class TestFrontEnd:
     @pytest.mark.parametrize("model", all_models, indirect=True)
     @pytest.mark.skipif(DEVICE.type == 'cpu', reason="Can only test on cuda")
     def test_cuda(self, model, einstein_img):
-        model.cuda()
-        model(einstein_img)
-        # make sure it ends on same device it started, since it's a fixture
-        model.to(DEVICE)
+        template_test_cuda(model, einstein_img)
 
     @pytest.mark.parametrize("model", all_models, indirect=True)
     @pytest.mark.skipif(DEVICE.type == 'cpu', reason="Can only test on cuda")
     def test_cpu_and_back(self, model, einstein_img):
-        model.cpu()
-        model.cuda()
-        model(einstein_img)
-        # make sure it ends on same device it started, since it's a fixture
-        model.to(DEVICE)
+        template_test_cpu_and_back(model, einstein_img)
 
     @pytest.mark.parametrize("model", all_models, indirect=True)
     @pytest.mark.skipif(DEVICE.type == 'cpu', reason="Can only test on cuda")
     def test_cuda_and_back(self, model, einstein_img):
-        model.cuda()
-        model.cpu()
-        model(einstein_img.cpu())
-        # make sure it ends on same device it started, since it's a fixture
-        model.to(DEVICE)
-        einstein_img.to(DEVICE)
+        template_test_cuda_and_back(model, einstein_img)
 
     @pytest.mark.parametrize("model", all_models, indirect=True)
     def test_cpu(self, model, einstein_img):
-        model.cpu()
-        model(einstein_img.cpu())
-        # make sure it ends on same device it started, since it's a fixture
-        model.to(DEVICE)
-        einstein_img.to(DEVICE)
+        template_test_cpu(model, einstein_img)
 
 class TestNaive(object):
 
@@ -279,37 +282,22 @@ class TestNaive(object):
     @pytest.mark.parametrize("model", all_models, indirect=True)
     @pytest.mark.skipif(DEVICE.type == 'cpu', reason="Can only test on cuda")
     def test_cuda(self, model, einstein_img):
-        model.cuda()
-        model(einstein_img)
-        # make sure it ends on same device it started, since it's a fixture
-        model.to(DEVICE)
+        template_test_cuda(model, einstein_img)
 
     @pytest.mark.parametrize("model", all_models, indirect=True)
     @pytest.mark.skipif(DEVICE.type == 'cpu', reason="Can only test on cuda")
     def test_cpu_and_back(self, model, einstein_img):
-        model.cpu()
-        model.cuda()
-        model(einstein_img)
-        # make sure it ends on same device it started, since it's a fixture
-        model.to(DEVICE)
+        template_test_cpu_and_back(model, einstein_img)
 
     @pytest.mark.parametrize("model", all_models, indirect=True)
     @pytest.mark.skipif(DEVICE.type == 'cpu', reason="Can only test on cuda")
     def test_cuda_and_back(self, model, einstein_img):
-        model.cuda()
-        model.cpu()
-        model(einstein_img.cpu())
-        # make sure it ends on same device it started, since it's a fixture
-        model.to(DEVICE)
-        einstein_img.to(DEVICE)
+        template_test_cuda_and_back(model, einstein_img)
 
     @pytest.mark.parametrize("model", all_models, indirect=True)
     def test_cpu(self, model, einstein_img):
-        model.cpu()
-        model(einstein_img.cpu())
-        # make sure it ends on same device it started, since it's a fixture
-        model.to(DEVICE)
-        einstein_img.to(DEVICE)
+        template_test_cpu(model, einstein_img)
+
 
 class TestPortillaSimoncelli(object):
     @pytest.mark.parametrize("n_scales", [1, 2, 3, 4])
@@ -522,29 +510,21 @@ class TestPortillaSimoncelli(object):
     @pytest.mark.skipif(DEVICE.type == 'cpu', reason="Can only test on cuda")
     def test_cuda(self, einstein_img):
         ps = po.simul.PortillaSimoncelli(einstein_img.shape[-2:])
-        ps.cuda()
-        ps(einstein_img)
+        template_test_cuda(ps, einstein_img)
 
     @pytest.mark.skipif(DEVICE.type == 'cpu', reason="Can only test on cuda")
     def test_cpu_and_back(self, einstein_img):
         ps = po.simul.PortillaSimoncelli(einstein_img.shape[-2:])
-        ps.cpu()
-        ps.cuda()
-        ps(einstein_img)
+        template_test_cpu_and_back(ps, einstein_img)
 
     @pytest.mark.skipif(DEVICE.type == 'cpu', reason="Can only test on cuda")
     def test_cuda_and_back(self, einstein_img):
         ps = po.simul.PortillaSimoncelli(einstein_img.shape[-2:])
-        ps.cuda()
-        ps.cpu()
-        ps(einstein_img.cpu())
-        einstein_img.to(DEVICE)
+        template_test_cuda_and_back(ps, einstein_img)
 
     def test_cpu(self, einstein_img):
         ps = po.simul.PortillaSimoncelli(einstein_img.shape[-2:])
-        ps.cpu()
-        ps(einstein_img.cpu())
-        einstein_img.to(DEVICE)
+        template_test_cpu(ps, einstein_img)
 
 
 class TestFilters:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -125,7 +125,7 @@ def test_cpu(model, einstein_img):
     model.to(DEVICE)
 
 @pytest.mark.parametrize("model", ALL_MODELS, indirect=True)
-def test_validate_model(model, einstein_img):
+def test_validate_model(model):
     po.tools.remove_grad(model)
     po.tools.validate.validate_model(model, device=DEVICE,
                                      image_shape=(1, 1, 256, 256))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -124,6 +124,11 @@ def test_cpu(model, einstein_img):
     einstein_img.to(DEVICE)
     model.to(DEVICE)
 
+@pytest.mark.parametrize("model", ALL_MODELS, indirect=True)
+def test_validate_model(model, einstein_img):
+    po.tools.remove_grad(model)
+    po.tools.validate.validate_model(model, device=DEVICE,
+                                     image_shape=(1, 1, 256, 256))
 
 class TestNonLinearities(object):
     def test_rectangular_to_polar_dict(self, basic_stim):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -130,6 +130,34 @@ class TestLaplacianPyramid(object):
             # after upsampling up to one row/column. This causes inconsistency on the right and
             # bottom edges, so they are exluded in the comparison.
 
+    @pytest.mark.skipif(DEVICE.type == 'cpu', reason="Can only test on cuda")
+    def test_cuda(self, einstein_img):
+        lpyr = po.simul.LaplacianPyramid()
+        lpyr.cuda()
+        lpyr(einstein_img)
+
+    @pytest.mark.skipif(DEVICE.type == 'cpu', reason="Can only test on cuda")
+    def test_cpu_and_back(self, einstein_img):
+        lpyr = po.simul.LaplacianPyramid()
+        lpyr.cpu()
+        lpyr.cuda()
+        lpyr(einstein_img)
+
+    @pytest.mark.skipif(DEVICE.type == 'cpu', reason="Can only test on cuda")
+    def test_cuda_and_back(self, einstein_img):
+        lpyr = po.simul.LaplacianPyramid()
+        lpyr.cuda()
+        lpyr.cpu()
+        lpyr(einstein_img.cpu())
+        # make sure it ends on same device it started, since it's a fixture
+        einstein_img.to(DEVICE)
+
+    def test_cpu(self, einstein_img):
+        lpyr = po.simul.LaplacianPyramid()
+        lpyr.cpu()
+        lpyr(einstein_img.cpu())
+        # make sure it ends on same device it started, since it's a fixture
+        einstein_img.to(DEVICE)
 
 class TestFrontEnd:
 
@@ -168,6 +196,40 @@ class TestFrontEnd:
         fig = model.display_filters()
         plt.close(fig)
 
+    @pytest.mark.parametrize("model", all_models, indirect=True)
+    @pytest.mark.skipif(DEVICE.type == 'cpu', reason="Can only test on cuda")
+    def test_cuda(self, model, einstein_img):
+        model.cuda()
+        model(einstein_img)
+        # make sure it ends on same device it started, since it's a fixture
+        model.to(DEVICE)
+
+    @pytest.mark.parametrize("model", all_models, indirect=True)
+    @pytest.mark.skipif(DEVICE.type == 'cpu', reason="Can only test on cuda")
+    def test_cpu_and_back(self, model, einstein_img):
+        model.cpu()
+        model.cuda()
+        model(einstein_img)
+        # make sure it ends on same device it started, since it's a fixture
+        model.to(DEVICE)
+
+    @pytest.mark.parametrize("model", all_models, indirect=True)
+    @pytest.mark.skipif(DEVICE.type == 'cpu', reason="Can only test on cuda")
+    def test_cuda_and_back(self, model, einstein_img):
+        model.cuda()
+        model.cpu()
+        model(einstein_img.cpu())
+        # make sure it ends on same device it started, since it's a fixture
+        model.to(DEVICE)
+        einstein_img.to(DEVICE)
+
+    @pytest.mark.parametrize("model", all_models, indirect=True)
+    def test_cpu(self, model, einstein_img):
+        model.cpu()
+        model(einstein_img.cpu())
+        # make sure it ends on same device it started, since it's a fixture
+        model.to(DEVICE)
+        einstein_img.to(DEVICE)
 
 class TestNaive(object):
 
@@ -214,6 +276,40 @@ class TestNaive(object):
         model = po.simul.Linear().to(DEVICE)
         assert model(basic_stim).requires_grad
 
+    @pytest.mark.parametrize("model", all_models, indirect=True)
+    @pytest.mark.skipif(DEVICE.type == 'cpu', reason="Can only test on cuda")
+    def test_cuda(self, model, einstein_img):
+        model.cuda()
+        model(einstein_img)
+        # make sure it ends on same device it started, since it's a fixture
+        model.to(DEVICE)
+
+    @pytest.mark.parametrize("model", all_models, indirect=True)
+    @pytest.mark.skipif(DEVICE.type == 'cpu', reason="Can only test on cuda")
+    def test_cpu_and_back(self, model, einstein_img):
+        model.cpu()
+        model.cuda()
+        model(einstein_img)
+        # make sure it ends on same device it started, since it's a fixture
+        model.to(DEVICE)
+
+    @pytest.mark.parametrize("model", all_models, indirect=True)
+    @pytest.mark.skipif(DEVICE.type == 'cpu', reason="Can only test on cuda")
+    def test_cuda_and_back(self, model, einstein_img):
+        model.cuda()
+        model.cpu()
+        model(einstein_img.cpu())
+        # make sure it ends on same device it started, since it's a fixture
+        model.to(DEVICE)
+        einstein_img.to(DEVICE)
+
+    @pytest.mark.parametrize("model", all_models, indirect=True)
+    def test_cpu(self, model, einstein_img):
+        model.cpu()
+        model(einstein_img.cpu())
+        # make sure it ends on same device it started, since it's a fixture
+        model.to(DEVICE)
+        einstein_img.to(DEVICE)
 
 class TestPortillaSimoncelli(object):
     @pytest.mark.parametrize("n_scales", [1, 2, 3, 4])
@@ -422,6 +518,33 @@ class TestPortillaSimoncelli(object):
         out_im = po.simul.PortillaSimoncelli(im_shape).expand(im, mult)
         
         assert out_im.shape == (im_shape[0] * mult, im_shape[1] * mult)
+
+    @pytest.mark.skipif(DEVICE.type == 'cpu', reason="Can only test on cuda")
+    def test_cuda(self, einstein_img):
+        ps = po.simul.PortillaSimoncelli(einstein_img.shape[-2:])
+        ps.cuda()
+        ps(einstein_img)
+
+    @pytest.mark.skipif(DEVICE.type == 'cpu', reason="Can only test on cuda")
+    def test_cpu_and_back(self, einstein_img):
+        ps = po.simul.PortillaSimoncelli(einstein_img.shape[-2:])
+        ps.cpu()
+        ps.cuda()
+        ps(einstein_img)
+
+    @pytest.mark.skipif(DEVICE.type == 'cpu', reason="Can only test on cuda")
+    def test_cuda_and_back(self, einstein_img):
+        ps = po.simul.PortillaSimoncelli(einstein_img.shape[-2:])
+        ps.cuda()
+        ps.cpu()
+        ps(einstein_img.cpu())
+        einstein_img.to(DEVICE)
+
+    def test_cpu(self, einstein_img):
+        ps = po.simul.PortillaSimoncelli(einstein_img.shape[-2:])
+        ps.cpu()
+        ps(einstein_img.cpu())
+        einstein_img.to(DEVICE)
 
 
 class TestFilters:

--- a/tests/test_steerable_pyr.py
+++ b/tests/test_steerable_pyr.py
@@ -8,6 +8,8 @@ import numpy as np
 from itertools import product
 from plenoptic.tools.data import to_numpy
 from conftest import DEVICE, DATA_DIR
+from test_models import (template_test_cuda, template_test_cpu_and_back,
+                         template_test_cuda_and_back, template_test_cpu)
 
 
 def check_pyr_coeffs(coeff_1, coeff_2, rtol=1e-3, atol=1e-3):
@@ -294,31 +296,21 @@ class TestSteerablePyramid(object):
     @pytest.mark.skipif(DEVICE.type == 'cpu', reason="Can only test on cuda")
     def test_cuda(self, img):
         pyr = po.simul.SteerablePyramidFreq(img.shape[-2:])
-        pyr.cuda()
-        pyr(img)
+        template_test_cuda(pyr, img)
 
     @pytest.mark.skipif(DEVICE.type == 'cpu', reason="Can only test on cuda")
     def test_cpu_and_back(self, img):
         pyr = po.simul.SteerablePyramidFreq(img.shape[-2:])
-        pyr.cpu()
-        pyr.cuda()
-        pyr(img)
+        template_test_cpu_and_back(pyr, img)
 
     @pytest.mark.skipif(DEVICE.type == 'cpu', reason="Can only test on cuda")
     def test_cuda_and_back(self, img):
         pyr = po.simul.SteerablePyramidFreq(img.shape[-2:])
-        pyr.cuda()
-        pyr.cpu()
-        pyr(img.cpu())
-        # make sure it ends on same device it started, since it's a fixture
-        img.to(DEVICE)
+        template_test_cuda_and_back(pyr, img)
 
     def test_cpu(self, img):
         pyr = po.simul.SteerablePyramidFreq(img.shape[-2:])
-        pyr.cpu()
-        pyr(img.cpu())
-        # make sure it ends on same device it started, since it's a fixture
-        img.to(DEVICE)
+        template_test_cpu(pyr, img)
 
     @pytest.mark.parametrize('order', range(1, 16))
     def test_buffers(self, order):

--- a/tests/test_steerable_pyr.py
+++ b/tests/test_steerable_pyr.py
@@ -290,3 +290,43 @@ class TestSteerablePyramid(object):
         with expectation:
             pyr = po.simul.SteerablePyramidFreq(img.shape[-2:], order=order).to(DEVICE)
             pyr(img)
+
+    @pytest.mark.skipif(DEVICE.type == 'cpu', reason="Can only test on cuda")
+    def test_cuda(self, img):
+        pyr = po.simul.SteerablePyramidFreq(img.shape[-2:])
+        pyr.cuda()
+        pyr(img)
+
+    @pytest.mark.skipif(DEVICE.type == 'cpu', reason="Can only test on cuda")
+    def test_cpu_and_back(self, img):
+        pyr = po.simul.SteerablePyramidFreq(img.shape[-2:])
+        pyr.cpu()
+        pyr.cuda()
+        pyr(img)
+
+    @pytest.mark.skipif(DEVICE.type == 'cpu', reason="Can only test on cuda")
+    def test_cuda_and_back(self, img):
+        pyr = po.simul.SteerablePyramidFreq(img.shape[-2:])
+        pyr.cuda()
+        pyr.cpu()
+        pyr(img.cpu())
+        # make sure it ends on same device it started, since it's a fixture
+        img.to(DEVICE)
+
+    def test_cpu(self, img):
+        pyr = po.simul.SteerablePyramidFreq(img.shape[-2:])
+        pyr.cpu()
+        pyr(img.cpu())
+        # make sure it ends on same device it started, since it's a fixture
+        img.to(DEVICE)
+
+    @pytest.mark.parametrize('order', range(1, 16))
+    def test_buffers(self, order):
+        pyr = po.simul.SteerablePyramidFreq((256, 256), order=order)
+        buffers = [k for k, _ in pyr.named_buffers()]
+        names = ['lo0mask', 'hi0mask']
+        for s in range(pyr.num_scales):
+            names.extend([f'_himasks_scale_{s}', f'_lomasks_scale_{s}',
+                          f'_anglemasks_scale_{s}', f'_anglemasks_recon_scale_{s}'])
+        assert len(buffers) == len(names), "pyramid doesn't have the right number of buffers!"
+        assert set(buffers) == set(names), "pyramid doesn't have the right buffers!"

--- a/tests/test_steerable_pyr.py
+++ b/tests/test_steerable_pyr.py
@@ -8,8 +8,6 @@ import numpy as np
 from itertools import product
 from plenoptic.tools.data import to_numpy
 from conftest import DEVICE, DATA_DIR
-from test_models import (template_test_cuda, template_test_cpu_and_back,
-                         template_test_cuda_and_back, template_test_cpu)
 
 
 def check_pyr_coeffs(coeff_1, coeff_2, rtol=1e-3, atol=1e-3):
@@ -292,25 +290,6 @@ class TestSteerablePyramid(object):
         with expectation:
             pyr = po.simul.SteerablePyramidFreq(img.shape[-2:], order=order).to(DEVICE)
             pyr(img)
-
-    @pytest.mark.skipif(DEVICE.type == 'cpu', reason="Can only test on cuda")
-    def test_cuda(self, img):
-        pyr = po.simul.SteerablePyramidFreq(img.shape[-2:])
-        template_test_cuda(pyr, img)
-
-    @pytest.mark.skipif(DEVICE.type == 'cpu', reason="Can only test on cuda")
-    def test_cpu_and_back(self, img):
-        pyr = po.simul.SteerablePyramidFreq(img.shape[-2:])
-        template_test_cpu_and_back(pyr, img)
-
-    @pytest.mark.skipif(DEVICE.type == 'cpu', reason="Can only test on cuda")
-    def test_cuda_and_back(self, img):
-        pyr = po.simul.SteerablePyramidFreq(img.shape[-2:])
-        template_test_cuda_and_back(pyr, img)
-
-    def test_cpu(self, img):
-        pyr = po.simul.SteerablePyramidFreq(img.shape[-2:])
-        template_test_cpu(pyr, img)
 
     @pytest.mark.parametrize('order', range(1, 16))
     def test_buffers(self, order):


### PR DESCRIPTION
With this PR, we make the models and canonical computations (everything in`plenoptic/simulate`) use `register_buffers`, which allows us to remove their `.to()` definitions and adds support for `.cpu()` and `.cuda()`. 

Note that this change *does not* affect the synthesis methods, because they're not modules. I may return to this at some point, but the rationale is because `torch.nn.Module` is the "base class for all neural network modules," as it says [in the docs](https://pytorch.org/docs/stable/generated/torch.nn.Module.html). Our models are similar enough that making them modules makes sense, but synthesis methods are fairly distinct (in particular, they don't necessarily involve optimization)

Closes #198 