### PR TITLE
fix for test_stop_criterion

### DIFF
--- a/tests/test_geodesic.py
+++ b/tests/test_geodesic.py
@@ -303,4 +303,5 @@ class TestGeodesic(object):
         moog = po.synth.Geodesic(einstein_small_seq[:1], einstein_small_seq[-1:],
                                  model, 5)
         moog.synthesize(max_iter=10, stop_criterion=.06, stop_iters_to_check=1)
-        assert len(moog.pixel_change_norm) == 6, "Didn't stop when hit criterion! (or optimization changed)"
+        assert (abs(moog.pixel_change_norm[-1:]) < .06).all(), "Didn't stop when hit criterion!"
+        assert not (abs(moog.pixel_change_norm[-2:]) < .06).all(), "Didn't stop when hit criterion!"

--- a/tests/test_geodesic.py
+++ b/tests/test_geodesic.py
@@ -304,4 +304,4 @@ class TestGeodesic(object):
                                  model, 5)
         moog.synthesize(max_iter=10, stop_criterion=.06, stop_iters_to_check=1)
         assert (abs(moog.pixel_change_norm[-1:]) < .06).all(), "Didn't stop when hit criterion!"
-        assert not (abs(moog.pixel_change_norm[-2:]) < .06).all(), "Didn't stop when hit criterion!"
+        assert (abs(moog.pixel_change_norm[:-1]) > .06).all(), "Stopped after hit criterion!"

--- a/tests/test_mad.py
+++ b/tests/test_mad.py
@@ -207,4 +207,5 @@ class TestMAD(object):
         po.tools.set_seed(0)
         mad = po.synth.MADCompetition(einstein_img, po.metric.mse, dis_ssim, 'min')
         mad.synthesize(max_iter=15, stop_criterion=1e-3, stop_iters_to_check=5)
-        assert len(mad.losses) == 12, "Didn't stop when hit criterion! (or optimization changed)"
+        assert abs(mad.losses[-5]-mad.losses[-1]) < 1e-3, "Didn't stop when hit criterion!"
+        assert abs(mad.losses[-6]-mad.losses[-2]) > 1e-3, "Stopped after hit criterion!"

--- a/tests/test_metamers.py
+++ b/tests/test_metamers.py
@@ -225,11 +225,6 @@ class TestMetamers(object):
         po.tools.set_seed(0)
         met = po.synth.Metamer(einstein_img, model)
         # takes different numbers of iter to converge on GPU and CPU
-        if DEVICE.type == 'cuda':
-            max_iter = 30
-            check_iter = 25
-        else:
-            max_iter = 10
-            check_iter = 8
-        met.synthesize(max_iter=max_iter, stop_criterion=1e-5, stop_iters_to_check=5)
-        assert len(met.losses) == check_iter, "Didn't stop when hit criterion! (or optimization changed)"
+        met.synthesize(max_iter=30, stop_criterion=1e-5, stop_iters_to_check=5)
+        assert abs(met.losses[-5]-met.losses[-1]) < 1e-5, "Didn't stop when hit criterion!"
+        assert abs(met.losses[-6]-met.losses[-2]) > 1e-5, "Stopped after hit criterion!"


### PR DESCRIPTION
on other OSs, can get a different sample of uniform noise when setting the seed to 0, which means it doesn't always hit the stop criterion at the same time. however, it should still *hit* the stop criterion, so we just test against that directly