### PR TITLE
Updates python versions and trove classifiers

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -32,7 +32,7 @@ If applicable, add screenshots to help explain your problem.
 
 **System (please complete the following information):**
  - OS: [e.g. Mac (with version), Ubuntu 18.04]
- - Python version [e.g. 3.7]
+ - Python version [e.g. 3.12]
  - Pytorch version [e.g., 1.4]
  - Plenoptic version [e.g. 0.1]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     needs: [get_notebooks]
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: ['3.10', '3.11', '3.12']
         notebook: ${{fromJson(needs.get_notebooks.outputs.notebook)}}
       fail-fast: false
     name: Execute notebooks
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: ['3.10', '3.11', '3.12']
       fail-fast: false
     name: Run pytest scripts
     steps:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.11"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,16 @@ We try to keep all our communication on Github, and we use several channels:
     of discussions first. We'll discuss it there and, if we decide to pursue it,
     open an issue to track progress.
 
+## Supported versions
+
+`plenoptic` tries to follow
+[SPEC-0](https://scientific-python.org/specs/spec-0000/): we support python
+versions are supported for 3 years following initial release. This means that we
+support three python feature versions (e.g., 3.10, 3.11, and 3.12) at any one
+time and that we'll transition between versions during the fourth quarter of
+each year. We run our CPU tests on all three versions, and the GPU tests and
+readthedocs build use the middle version.
+
 ## Contributing to the code
 
 ### Contribution workflow

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI Version](https://img.shields.io/pypi/v/plenoptic.svg)](https://pypi.org/project/plenoptic/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/LabForComputationalVision/plenoptic/blob/main/LICENSE)
-![Python version](https://img.shields.io/badge/python-3.7|3.8|3.9|3.10-blue.svg)
+![Python version](https://img.shields.io/badge/python-3.10|3.11|3.12-blue.svg)
 [![Build Status](https://github.com/LabForComputationalVision/plenoptic/workflows/build/badge.svg)](https://github.com/LabForComputationalVision/plenoptic/actions?query=workflow%3Abuild)
 [![Documentation Status](https://readthedocs.org/projects/plenoptic/badge/?version=latest)](https://plenoptic.readthedocs.io/en/latest/?badge=latest)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.10151131.svg)](https://doi.org/10.5281/zenodo.10151131)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@
 .. |license-shield| image:: https://img.shields.io/badge/license-MIT-yellow.svg
                     :target: https://github.com/LabForComputationalVision/plenoptic/blob/main/LICENSE
 
-.. |python-version-shield| image:: https://img.shields.io/badge/python-3.7%7C3.8%7C3.9%7C3.10-blue.svg
+.. |python-version-shield| image:: https://img.shields.io/badge/python-3.10%7C3.11%7C3.12-blue.svg
 
 .. |build| image:: https://github.com/LabForComputationalVision/plenoptic/workflows/build/badge.svg
 		     :target: https://github.com/LabForComputationalVision/plenoptic/actions?query=workflow%3Abuild

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -2,12 +2,12 @@ FROM nvidia/cuda:12.2.0-devel-ubuntu20.04
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
-      python3-numpy \
-      python3-pip \
-      python3-pytest \
-      python3-pytest-cov \
-      python3-venv \
-      python3-yaml \
+      python3.11-numpy \
+      python3.11-pip \
+      python3.11-pytest \
+      python3.11-pytest-cov \
+      python3.11-venv \
+      python3.11-yaml \
       ffmpeg \
       git \
       && \

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.2.0-devel-ubuntu20.04
+FROM nvidia/cuda:12.2.0-devel-ubuntu22.04
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -2,7 +2,8 @@ FROM nvidia/cuda:12.2.0-devel-ubuntu20.04
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
-      python3.11-venv \
+      'python-3.11' \
+      'python3.11-venv' \
       ffmpeg \
       git \
       && \

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -2,12 +2,7 @@ FROM nvidia/cuda:12.2.0-devel-ubuntu20.04
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
-      python3.11-numpy \
-      python3.11-pip \
-      python3.11-pytest \
-      python3.11-pytest-cov \
       python3.11-venv \
-      python3.11-yaml \
       ffmpeg \
       git \
       && \

--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -2,7 +2,7 @@ FROM nvidia/cuda:12.2.0-devel-ubuntu22.04
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
-      'python-3.11' \
+      'python3.11' \
       'python3.11-venv' \
       ffmpeg \
       git \

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -25,13 +25,13 @@ pipeline {
 	OMP_NUM_THREADS = 4
       }
       steps {
-	sh 'python3 -m venv --system-site-packages $HOME'
+	sh 'python3.11 -m venv --system-site-packages $HOME'
 	sh '''#!/bin/bash -ex
 	  source $HOME/bin/activate
       pip install -U pip
 	  pip install -U .[dev] --verbose
-      python3 -c "import torch; print(torch.cuda.current_device())"
-	  python3 -m pytest
+      python3.11 -c "import torch; print(torch.cuda.current_device())"
+	  python3.11 -m pytest
 	'''
       }
     }
@@ -52,13 +52,13 @@ pipeline {
 	OMP_NUM_THREADS = 4
       }
       steps {
-	sh 'python3 -m venv --system-site-packages $HOME'
+	sh 'python3.11 -m venv --system-site-packages $HOME'
 	sh '''#!/bin/bash -ex
 	  source $HOME/bin/activate
       pip install -U pip
 	  pip install .[dev]
-      python3 -c "import torch; print(torch.cuda.current_device())"
-	  python3 -m pytest
+      python3.11 -c "import torch; print(torch.cuda.current_device())"
+	  python3.11 -m pytest
 	'''
       }
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,12 @@ dynamic = ["version"]
 authors = [{name="Plenoptic authors"}]
 description = "Python library for model-based stimulus synthesis."
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 classifiers = [
-    "Development Status :: 4 - Beta",
-    "Programming Language :: Python :: 3",
+    "Development Status :: 5 - Production/Stable",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: MIT License",
     "Intended Audience :: Science/Research",
 ]


### PR DESCRIPTION
With this, we update our supported python versions from 3.7-3.11 to 3.10-3.12, in order to be compliant with [SPEC0](https://scientific-python.org/specs/spec-0000/).

From now on, following that, we will support three python minor versions, rolling them over at the end of the year.

Closes #247 