### PR TITLE
Avoid unnecessary computation of magnitude variance in Portilla-Simoncelli model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         pip install --upgrade --upgrade-strategy eager .[dev]
     - name: Run tests with pytest
       run: |
-        pytest -n auto --cov-report xml
+        pytest --cov-report xml
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@7598e39340e1dff4d6ebf7cf07a5e8184bde67e7 # v4.0.1
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,6 @@ version_scheme = 'python-simplified-semver'
 local_scheme = 'no-local-version'
 
 [tool.pytest.ini_options]
-addopts = "--cov=plenoptic"
+addopts = "--cov=plenoptic -n auto"
 testpaths = ["tests"]
 

--- a/src/plenoptic/data/fetch.py
+++ b/src/plenoptic/data/fetch.py
@@ -24,6 +24,7 @@ REGISTRY = {
     'portilla_simoncelli_synthesize_torch_v1.12.0_ps-refactor.npz': '9525844b71cf81509b86ed9677172745353588c6bb54e4de8000d695598afa47',
     'portilla_simoncelli_synthesize_gpu_ps-refactor.npz': '9fbb490f1548133f6aa49c54832130cf70f8dc6546af59688ead17f62ab94e61',
     'portilla_simoncelli_scales_ps-refactor.npz': '1053790a37707627810482beb0dd059cbc193efd688b60c441b3548a75626fdf',
+    'portilla_simoncelli_synthesize_torch_v1.12.0_ps-refactor-2.npz': 'ffd967543d58a03df390008c35878791590520624aa0e5e5a26ad3f877345ab4',
 }
 
 OSF_TEMPLATE = "https://osf.io/{}/download"
@@ -48,6 +49,7 @@ REGISTRY_URLS = {
     'portilla_simoncelli_synthesize_torch_v1.12.0_ps-refactor.npz': OSF_TEMPLATE.format('vmwzd'),
     'portilla_simoncelli_synthesize_gpu_ps-refactor.npz': OSF_TEMPLATE.format('mqs6y'),
     'portilla_simoncelli_scales_ps-refactor.npz': OSF_TEMPLATE.format('nvpr4'),
+    'portilla_simoncelli_synthesize_torch_v1.12.0_ps-refactor-2.npz': OSF_TEMPLATE.format('en8du'),
 }
 DOWNLOADABLE_FILES = list(REGISTRY_URLS.keys())
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -682,7 +682,7 @@ class TestPortillaSimoncelli(object):
         scales_dict['auto_correlation_magnitude'] = scales_dict['auto_correlation_magnitude'].transpose(0, 1, 3, 2)
         output = einops.pack(list(scales_dict.values()), '*')[0]
         # just select the scales of the necessary stats.
-        output = output[model._necessary_stats_mask]
+        output = output[model._necessary_stats_mask.cpu()]
 
         np.testing.assert_equal(output, saved)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -74,8 +74,8 @@ def get_portilla_simoncelli_synthesize_filename(torch_version=None):
     # during refactor, we changed PS model output so that it doesn't include
     # redundant stats. This changes the solution that is found (though not its
     # quality)
-    name_template = 'portilla_simoncelli_synthesize{gpu}{torch_version}_ps-refactor.npz'
-    # synthesis gives differnet outputs on cpu vs gpu, so we have two different
+    name_template = 'portilla_simoncelli_synthesize{gpu}{torch_version}_ps-refactor-2.npz'
+    # synthesis gives different outputs on cpu vs gpu, so we have two different
     # versions to test against
     if DEVICE.type == 'cpu':
         gpu = ''

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -52,7 +52,7 @@ def portilla_simoncelli_test_vectors():
 
 
 @pytest.fixture()
-def portilla_simoncelli_synthesize(torch_version=None):
+def portilla_simoncelli_synthesize():
     return po.data.fetch_data('portilla_simoncelli_synthesize_torch_v1.12.0_ps-refactor-2.npz')
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -51,42 +51,9 @@ def portilla_simoncelli_test_vectors():
     return po.data.fetch_data('portilla_simoncelli_test_vectors_refactor.tar.gz')
 
 
-def get_portilla_simoncelli_synthesize_filename(torch_version=None):
-    """Helper function to get pathname.
-
-    We can't call fixtures directly (feature removed in pytest 4.0), so we use
-    this helper function to get the name, which we use in
-    tests/utils.update_ps_synthesis_test_file()
-
-    """
-    if torch_version is None:
-        # the bit after the + defines the CUDA version used (if any), which
-        # doesn't appear to be relevant for this.
-        torch_version = torch.__version__.split('+')[0]
-    # following https://stackoverflow.com/a/11887885 for how to compare version
-    # strings
-    if version.parse(torch_version) < version.parse('1.12') or DEVICE.type == 'cuda':
-        torch_version = ''
-    # going from 1.11 to 1.12 only changes this synthesis output on cpu, not
-    # gpu
-    else:
-        torch_version = '_torch_v1.12.0'
-    # during refactor, we changed PS model output so that it doesn't include
-    # redundant stats. This changes the solution that is found (though not its
-    # quality)
-    name_template = 'portilla_simoncelli_synthesize{gpu}{torch_version}_ps-refactor-2.npz'
-    # synthesis gives different outputs on cpu vs gpu, so we have two different
-    # versions to test against
-    if DEVICE.type == 'cpu':
-        gpu = ''
-    elif DEVICE.type == 'cuda':
-        gpu = '_gpu'
-    return name_template.format(gpu=gpu, torch_version=torch_version)
-
-
 @pytest.fixture()
 def portilla_simoncelli_synthesize(torch_version=None):
-    return po.data.fetch_data(get_portilla_simoncelli_synthesize_filename(torch_version))
+    return po.data.fetch_data('portilla_simoncelli_synthesize_torch_v1.12.0_ps-refactor-2.npz')
 
 
 @pytest.fixture()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -47,7 +47,7 @@ def update_ps_synthesis_test_file(torch_version: Optional[str] = None):
     met = TestPortillaSimoncelli().test_ps_synthesis(ps_synth_file, False)
 
     torch_v = torch.__version__.split('+')[0]
-    file_name_parts = re.findall('(.*portilla_simoncelli_synthesize)(_gpu)?(_torch_v)?([0-9.]*)(_ps-refactor)?.npz',
+    file_name_parts = re.findall('(.*portilla_simoncelli_synthesize)(_gpu)?(_torch_v)?([0-9.]*)(_ps-refactor)?(-2)?.npz',
                                  ps_synth_file.name)[0]
     output_file_name = ''.join(file_name_parts[:2]) + f'_torch_v{torch_v}{file_name_parts[-1]}.npz'
     output = po.to_numpy(met.metamer).squeeze()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -21,7 +21,7 @@ def update_ps_synthesis_test_file(torch_version: Optional[str] = None):
     After generating this file and checking it looks good, upload it to the OSF
     plenoptic-files project: https://osf.io/ts37w/files/osfstorage, then update
     test_models.get_portilla_simoncelli_synthesize_filename and
-    test_metric.OSF_URL
+    fetch.REGISTRY_URLS and fetch.REGISTRY
 
     Parameters
     ----------
@@ -48,7 +48,7 @@ def update_ps_synthesis_test_file(torch_version: Optional[str] = None):
 
     torch_v = torch.__version__.split('+')[0]
     file_name_parts = re.findall('(.*portilla_simoncelli_synthesize)(_gpu)?(_torch_v)?([0-9.]*)(_ps-refactor)?.npz',
-                                 ps_synth_file)[0]
+                                 ps_synth_file.name)[0]
     output_file_name = ''.join(file_name_parts[:2]) + f'_torch_v{torch_v}{file_name_parts[-1]}.npz'
     output = po.to_numpy(met.metamer).squeeze()
     rep = po.to_numpy(met.model(met.metamer)).squeeze()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,7 +5,7 @@ import re
 import plenoptic as po
 import pyrtools as pt
 import numpy as np
-from test_models import TestPortillaSimoncelli, get_portilla_simoncelli_synthesize_filename
+from test_models import TestPortillaSimoncelli
 from typing import Optional
 
 
@@ -35,7 +35,7 @@ def update_ps_synthesis_test_file(torch_version: Optional[str] = None):
         Metamer object for inspection
 
     """
-    ps_synth_file = po.data.fetch_data(get_portilla_simoncelli_synthesize_filename(torch_version))
+    ps_synth_file = po.data.fetch_data('portilla_simoncelli_synthesize_torch_v1.12.0_ps-refactor-2.npz')
     print(f'Loading from {ps_synth_file}')
 
     with np.load(ps_synth_file) as f:


### PR DESCRIPTION
I realized that `PortillaSimoncelli._compute_cross_correlation` was always computing the variance itself (for normalizing the covariance to a cross-correlation), but that this was unnecessary because, in two of the three calls, it was computing the variance of each magnitude band, which had already been computed (while computing the auto-correlation of those magnitude bands). This refactor then allows us to make use of that fact, only computing the variance as necessary.

In this model, the above change does not change the total forward time by a noticeable amount. It will, however, help the pooled Portilla-Simoncelli model.

Additionally, I swapped the final two dimensions of the magnitude bands' auto-correlations, changing their shape from `(batch, channel, spatial_corr_width, spatial_corr_width, n_scales, n_orientations)` to `(batch, channel, spatial_corr_width, spatial_corr_width, n_orientations, n_scales)`. This makes their shape more consistent with the other stats, which always have `n_scales` as the final dimension. As a result, it makes the representation plot a bit easier to interpret.

The first change above does mean that the metamer output is slightly, but not perceptually, different from before, so needed to update the contents of the test files. While doing so, I realized that the GPU and CPU synthesis outputs are now identical. I doubt that's related to these changes, but unsure when that happened.

Finally, also added `-n auto` to our pytest configuration in `pyproject.toml`, so that pytest will take advantage of parallelization by default (this won't affect the CI, which had manually added that arg).